### PR TITLE
Add Logo and Down Arrows to home page

### DIFF
--- a/src/components/why-it-matters/index.js
+++ b/src/components/why-it-matters/index.js
@@ -1,10 +1,11 @@
 import { useContext } from "react";
 import { Context } from "../../state";
-
+// @ts-ignore
+import arrowsDown from "../../../assets/images/arrows-down.svg";
 import "./why-it-matters.css";
 
 const WhyItMatters = () => {
-  const [state, dispatch] = useContext(Context);
+  const [state] = useContext(Context);
   const { translations, locale } = state;
   const lang = translations[locale];
 
@@ -17,7 +18,8 @@ const WhyItMatters = () => {
       <div className="h-screen flex flex-col justify-start">
         <div className="birds-01 absolute"></div>
         <div className="birds-02 absolute"></div>
-        <div className="h-56 w-56 mb-28 bg-logo bg-contain bg-no-repeat bg-center self-center md:hidden"></div>
+        <div className="hidden md:block bg-logo absolute top-0 right-0 mt-9 mr-9 invert bg-contain bg-no-repeat h-36 md:h-32 aspect-square"></div>
+        <div className="md:hidden h-56 w-56 mb-28 bg-logo bg-contain bg-no-repeat bg-center self-center"></div>
         <div className="h-screen-70vh flex flex-col-reverse md:flex-row md:pt-16">
           <div
             id="elephant-image-container"
@@ -46,13 +48,13 @@ const WhyItMatters = () => {
             </div>
           </div>
         </div>
-
         <div className="h-screen-10vh p-4 md:p-10 -mt-48 md:mt-0">
           <div className="text-center">
             <h5 className="pb-8 px-20 text-5xl md:text-base">
               {lang["it-matters"]}
             </h5>
-            <span className="badge uppercase">{lang["begin-learning"]}</span>
+            <span className="badge uppercase">{lang["scroll-down"]}</span>
+            <img className="mx-auto mt-10 h-[50px]" src={arrowsDown} />
           </div>
         </div>
       </div>

--- a/src/utils/translations.js
+++ b/src/utils/translations.js
@@ -7,8 +7,7 @@ const en = {
     "When we suffer, we seek relief. For animals, their suffering doesn't become any less pleasant because they live in the wild, and pain feels the same for them, regardless of whether or not humans are the cause of it. The suffering of wild animals matters. It matters to them, and it should matter to us.",
   "it-matters":
     "The suffering of wild animals matters. It matters to them, and it should matter to us.",
-  "scroll-down": "Scroll down to begin learning!",
-  "begin-learning": "Begin learning",
+  "scroll-down": "Scroll Down to Begin",
   "human-population":
     'There are roughly <span className="blue">8 billion humans</span> on planet Earth.',
   "for-every-human":


### PR DESCRIPTION
- Add logo to top right corner
- Add down arrows at bottom
- Change "Begin Learning" to "Scroll Down to Begin"

Notes:
- The logo in top right transforms on mobile view (see demo)
- Will fix responsive design of down arrows in future 

## Demo

https://user-images.githubusercontent.com/39889198/196006256-9be2711b-62d0-404b-8975-8667511636ae.mov

