### PR TITLE
Increase responsiveness of Common Objections screen

### DIFF
--- a/src/components/accordion.js
+++ b/src/components/accordion.js
@@ -42,7 +42,7 @@ export function AccordionItem({ index, label, content, value, ...props }) {
           "radix-state-closed:animate-slide-up radix-state-open:animate-slide-down"
         )}
       >
-        <div className="py-5 pl-18 pr-5">{content}</div>
+        <div className="py-5 px-5 sm:pl-18">{content}</div>
       </RadixAccordion.Content>
     </RadixAccordion.Item>
   );

--- a/src/screens/common-objections/index.js
+++ b/src/screens/common-objections/index.js
@@ -4,13 +4,9 @@ export function CommonObjections() {
   return (
     <section
       id="common-objections"
-      className="relative min-h-screen bg-sand bg-top py-24"
+      className="relative flex min-h-screen bg-sand bg-cover bg-top py-24"
     >
-      <img
-        className="not-sr-only absolute bottom-0 w-full"
-        src="/images/common-objections/grass-and-hedgehog.png"
-        alt=""
-      />
+      <div className="absolute bottom-0 h-full w-full bg-hedgehog bg-right-bottom bg-no-repeat xl:bg-contain" />
       <div className="relative mx-auto flex w-full max-w-7xl flex-col space-y-10 px-10">
         <h2 className="text-center font-brand text-4xl text-white">
           Common objections to helping wild animals

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,6 +63,8 @@ module.exports = {
         abyss: "url('/public/images/scale-of-suffering/abyss.jpg')",
         "dirt-road": "url('/public/images/population-dynamics/dirt-road.jpg')",
         frog: "url('/public/images/organizations/frog.png')",
+        hedgehog:
+          "url('/public/images/common-objections/grass-and-hedgehog.png')",
         mud: "url('/public/images/organizations/mud-bg-color.jpg')",
         sand: "url('/public/images/types-of-suffering/sand-bg-color.jpg')",
         savanna: "url('/public/images/introduction/savanna.jpg')",


### PR DESCRIPTION
This screen is a bit awkward. It turns out vertical centering doesn't quite work because of our hedgehog friend. I think this is overall okay for MVP, though.

![Cursor_and_Wild_Animal_Suffering_—_The_scale__the_problem__and_why_it_matters](https://user-images.githubusercontent.com/748180/201754167-f185c2a6-7d11-4386-9a24-21dd1dc4cb06.png)

![Cursor_and_Wild_Animal_Suffering_—_The_scale__the_problem__and_why_it_matters_and_index_js_—_wildanimalsuffering](https://user-images.githubusercontent.com/748180/201754250-610af255-eb9d-4ad7-8168-7676a208f480.png)

![Cursor_and_Wild_Animal_Suffering_—_The_scale__the_problem__and_why_it_matters](https://user-images.githubusercontent.com/748180/201754327-958174a2-322e-4713-98c4-a4bc3965b0b6.png)

![Cursor_and_Wild_Animal_Suffering_—_The_scale__the_problem__and_why_it_matters](https://user-images.githubusercontent.com/748180/201754677-e38fc705-dc62-4a69-900d-21e4eaba380a.png)
