### PR TITLE
Address a couple issues on the population dynamics screen

### DIFF
--- a/src/screens/population-dynamics/index.js
+++ b/src/screens/population-dynamics/index.js
@@ -94,14 +94,26 @@ export function PopulationDynamics() {
         </div>
       </div>
 
-      <div className="relative mx-auto flex w-full max-w-7xl flex-1 flex-col space-y-4 px-8 sm:space-y-10">
+      <div className="relative mx-auto flex w-full max-w-7xl flex-1 flex-col gap-4 px-8 sm:gap-10">
         <h2 className="font-brand text-4xl text-white">Population Dynamics</h2>
-        <p className="text-lg text-white sm:max-w-sm md:max-w-xl lg:max-w-2xl">
-          Wild animals tend to have a lot of children, and for populations to
-          remain stable, on average each parent can only have 2 children that
-          reach adulthood.{" "}
-          <strong>This means that most animals die young.</strong>
-        </p>
+        <div className="flex flex-col gap-4">
+          <p className="text-lg text-white sm:max-w-sm md:max-w-xl lg:max-w-2xl">
+            Wild animals tend to have a lot of children, and for populations to
+            remain stable, on average each parent can only have 2 children that
+            reach adulthood.{" "}
+            <strong>This means that most animals die young.</strong>
+          </p>
+          <div>
+            <a
+              href="https://www.animal-ethics.org/population-dynamics-animal-suffering/"
+              className="rounded-full bg-primary px-14 py-1 text-lg"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Learn more
+            </a>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/src/screens/population-dynamics/index.js
+++ b/src/screens/population-dynamics/index.js
@@ -45,12 +45,6 @@ export function PopulationDynamics() {
           />
           <motion.img
             style={{ opacity: chickOpacity }}
-            className="col-start-1 row-start-2 translate-x-20 opacity-50 grayscale"
-            src="/images/population-dynamics/chick.png"
-            alt=""
-          />
-          <motion.img
-            style={{ opacity: chickOpacity }}
             className="col-start-1 row-start-3 translate-y-20 opacity-50 grayscale"
             src="/images/population-dynamics/chick.png"
             alt=""
@@ -91,12 +85,18 @@ export function PopulationDynamics() {
             src="/images/population-dynamics/chick.png"
             alt=""
           />
+          <motion.img
+            style={{ opacity: chickOpacity }}
+            className="col-start-3 row-start-5 translate-x-20 opacity-50 grayscale"
+            src="/images/population-dynamics/chick.png"
+            alt=""
+          />
         </div>
       </div>
 
-      <div className="relative mx-auto flex w-full max-w-2xl flex-1 flex-col space-y-4 px-8 sm:space-y-10">
+      <div className="relative mx-auto flex w-full max-w-7xl flex-1 flex-col space-y-4 px-8 sm:space-y-10">
         <h2 className="font-brand text-4xl text-white">Population Dynamics</h2>
-        <p className="text-lg text-white">
+        <p className="text-lg text-white sm:max-w-sm md:max-w-xl lg:max-w-2xl">
           Wild animals tend to have a lot of children, and for populations to
           remain stable, on average each parent can only have 2 children that
           reach adulthood.{" "}


### PR DESCRIPTION
Two things:

1. "Learn more" button was added
2. The text is no longer completely centered, because it caused too much overlap with the duck on shorter monitors (e.g. laptops).

<img width="1679" alt="Wild_Animal_Suffering_—_The_scale__the_problem__and_why_it_matters_🔊" src="https://user-images.githubusercontent.com/748180/202857732-3d29347a-d7c3-4d65-870e-37a4e784938f.png">
