### PR TITLE
Add trailing slash

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const withExportImages = require("next-export-optimize-images");
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  trailingSlash: true,
 };
 
 module.exports = withExportImages(nextConfig);


### PR DESCRIPTION
Without this, `/pages/fr.tsx` would yield `/fr.html` instead of `/fr/index.html`.