### PR TITLE
Language switcher

### DIFF
--- a/components/chevron-down-icon.tsx
+++ b/components/chevron-down-icon.tsx
@@ -1,0 +1,13 @@
+export function ChevronDownIcon() {
+  return (
+    <svg width="15" height="9" viewBox="0 0 15 9" fill="none">
+      <path
+        d="M2.09155 2.29578L7.20878 7.57418C7.24613 7.61523 7.29124 7.64795 7.34133 7.67032C7.39142 7.69269 7.44542 7.70423 7.5 7.70423C7.55458 7.70423 7.60859 7.69269 7.65867 7.67032C7.70876 7.64795 7.75388 7.61523 7.79123 7.57418L12.9085 2.29578"
+        stroke="currentColor"
+        strokeWidth="1.85"
+        strokeLinecap="square"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -7,6 +7,9 @@ type Props = {
   locale?: keyof typeof resources;
 };
 
+// Remove this when new languages get added
+const hasMultipleLanguages = false;
+
 export function Header({ locale = "en" }: Props) {
   const { t } = useTranslation();
 
@@ -21,10 +24,12 @@ export function Header({ locale = "en" }: Props) {
     <header className="absolute left-0 z-20 flex w-full items-center gap-8 p-10 text-white">
       <Navigation />
 
-      <Select defaultValue={locale} onChange={onLangChange}>
-        <option value="en">En</option>
-        <option value="fr">Fr</option>
-      </Select>
+      {hasMultipleLanguages && (
+        <Select defaultValue={locale} onChange={onLangChange}>
+          <option value="en">En</option>
+          <option value="fr">Fr</option>
+        </Select>
+      )}
 
       <span className="hidden font-light md:block">
         <Trans i18nKey="header.credits" className="hidden font-light md:block">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,12 +1,30 @@
+import { resources } from "i18n";
 import { Trans, useTranslation } from "react-i18next";
 import { Navigation } from "~/components/navigation";
+import { Select } from "./select";
 
-export function Header() {
+type Props = {
+  locale?: keyof typeof resources;
+};
+
+export function Header({ locale = "en" }: Props) {
   const { t } = useTranslation();
 
+  const onLangChange = (event: React.FormEvent<HTMLSelectElement>) => {
+    if (event.target instanceof HTMLSelectElement) {
+      const { value } = event.target;
+      location.href = value === "en" ? "/" : `/${value}/`;
+    }
+  };
+
   return (
-    <header className="absolute left-0 z-20 flex w-full items-center gap-8 p-10 text-gray md:text-white">
+    <header className="absolute left-0 z-20 flex w-full items-center gap-8 p-10 text-white">
       <Navigation />
+
+      <Select defaultValue={locale} onChange={onLangChange}>
+        <option value="en">En</option>
+        <option value="fr">Fr</option>
+      </Select>
 
       <span className="hidden font-light md:block">
         <Trans i18nKey="header.credits" className="hidden font-light md:block">

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -23,13 +23,16 @@ export function Navigation() {
 
   return (
     <>
-      <button className="cursor-pointer" onClick={() => setOpen(true)}>
+      <button
+        className="mr-auto cursor-pointer md:mr-0"
+        onClick={() => setOpen(true)}
+      >
         <span className="sr-only">{t("navigation.name")}</span>
         <MenuIcon size={35} className="cursor-pointer" />
       </button>
 
       {open && (
-        <nav className="absolute top-0 left-0 h-auto w-full overflow-auto p-5 sm:max-w-sm">
+        <nav className="absolute top-0 left-0 z-10 h-auto w-full overflow-auto p-5 sm:max-w-sm">
           <div className="flex flex-col overflow-auto rounded-xl bg-white text-menu-front-dark">
             <div className="flex justify-between p-8">
               <div className="font-brand text-2xl uppercase text-menu-front-dark">

--- a/components/select.tsx
+++ b/components/select.tsx
@@ -1,0 +1,18 @@
+import { ChevronDownIcon } from "./chevron-down-icon";
+
+type Props = React.HTMLProps<HTMLSelectElement> & {
+  children?: React.ReactNode;
+};
+
+export function Select({ children, ...props }: Props) {
+  return (
+    <div className="relative">
+      <span className="pointer-events-none absolute right-2 top-0 grid h-full place-items-center items-center gap-4">
+        <ChevronDownIcon />
+      </span>
+      <select className="appearance-none bg-transparent pl-2 pr-8" {...props}>
+        {children}
+      </select>
+    </div>
+  );
+}

--- a/pages/fr.tsx
+++ b/pages/fr.tsx
@@ -1,7 +1,7 @@
 import Home from "~/screens/home";
 
 export default function Fr() {
-  return <Home />;
+  return <Home locale="fr" />;
 }
 
 export function getStaticProps() {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Home from "~/screens/home";
 
 export default function En() {
-  return <Home />;
+  return <Home locale="en" />;
 }
 
 export function getStaticProps() {

--- a/screens/home.tsx
+++ b/screens/home.tsx
@@ -21,7 +21,7 @@ export default function Home({ locale }: Props) {
 
   return (
     <>
-      <Header />
+      <Header locale={locale} />
       <main>
         <Introduction />
         <ScaleOfSuffering />


### PR DESCRIPTION
<img width="1455" alt="Screenshot 2023-03-25 at 15 35 48" src="https://user-images.githubusercontent.com/4006802/227723774-69ef1eb2-1723-402c-ba7a-05504bc9f7da.png">

Currently disabled, since we only have translations available for one language at the moment. But as soon as the French translations are done, we can enable the language switcher (and update `robots.txt`).